### PR TITLE
Add Creator Coin Market Cap Comparison Function

### DIFF
--- a/battle-score/.gitignore
+++ b/battle-score/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/battle-score/README.md
+++ b/battle-score/README.md
@@ -1,0 +1,111 @@
+# Battle Scores
+
+A TypeScript SDK for comparing Zora creator coin market cap performance over time periods.
+
+## Overview
+
+This package provides functionality to compare two creator coins' market cap changes and determine which performed better over a specified time period.
+
+## Documentation
+
+https://docs.zora.co/coins/sdk/queries/explore#usage-example
+
+## Installation
+
+```bash
+npm install @zoralabs/coins-sdk
+```
+
+## API Reference
+
+### `compareCoinMarketCaps(input: CoinComparisonInput): Promise<CoinComparisonResult>`
+
+Compares market cap performance between two creator coins over a specified time period.
+
+#### Parameters
+
+```typescript
+interface CoinComparisonInput {
+  coinAddress1: string;    // First creator coin contract address
+  coinAddress2: string;    // Second creator coin contract address  
+  startTimestamp: number;  // Unix timestamp to start measuring from
+  chainId?: number;        // Optional chain ID (defaults to 8453 - Base)
+}
+```
+
+#### Return Value
+
+```typescript
+interface CoinComparisonResult {
+  coin1: CoinMetrics;
+  coin2: CoinMetrics;
+  comparisonScore: number;           // Ratio: coin1_increase / coin2_increase
+  winner: 'coin1' | 'coin2' | 'tie';
+}
+
+interface CoinMetrics {
+  address: string;              // Contract address
+  symbol: string;               // Coin symbol
+  name: string;                 // Coin name
+  startMarketCap: string;       // Market cap at start timestamp (USDC)
+  currentMarketCap: string;     // Current market cap (USDC)
+  marketCapIncreaseUsdc: string; // Absolute increase in USDC
+  percentageIncrease: number;   // Percentage increase
+}
+```
+
+#### Algorithm
+
+1. **Current Data Retrieval**: Fetches current market cap data for both coins using `getCoin()`
+2. **Historical Price Discovery**: Uses `getCoinSwaps()` to find the swap activity closest to the `startTimestamp`
+3. **Market Cap Calculation**: 
+   - Historical market cap = `historical_price * total_supply`
+   - Current market cap = `current_price * total_supply`
+   - Increase = `current_market_cap - historical_market_cap`
+4. **Comparison Scoring**:
+   - `comparisonScore = coin1_increase / coin2_increase`
+   - Winner determined by highest absolute USDC increase
+   - Tie if increases differ by less than $0.01
+
+#### Usage Example
+
+```typescript
+import { compareCoinMarketCaps } from './coinComparison';
+
+async function example() {
+  const result = await compareCoinMarketCaps({
+    coinAddress1: '0x1234567890123456789012345678901234567890',
+    coinAddress2: '0x0987654321098765432109876543210987654321',
+    startTimestamp: Math.floor(Date.now() / 1000) - (7 * 24 * 60 * 60), // 7 days ago
+    chainId: 8453 // Base chain
+  });
+
+  console.log(`Winner: ${result.winner}`);
+  console.log(`${result.coin1.symbol}: $${result.coin1.marketCapIncreaseUsdc} (+${result.coin1.percentageIncrease.toFixed(2)}%)`);
+  console.log(`${result.coin2.symbol}: $${result.coin2.marketCapIncreaseUsdc} (+${result.coin2.percentageIncrease.toFixed(2)}%)`);
+  console.log(`Comparison Score: ${result.comparisonScore.toFixed(2)}`);
+}
+```
+
+#### Error Handling
+
+- Throws error if coin addresses are invalid or not found
+- Returns `0` for historical market cap if no swap data exists near `startTimestamp`
+- Gracefully handles missing price data with fallback values
+- Network errors are propagated to caller
+
+#### Limitations
+
+- Historical accuracy depends on swap activity frequency
+- Limited by available historical data depth in the Zora API
+- Requires at least one swap transaction near the start timestamp for accurate historical pricing
+- Market cap calculations assume consistent total supply (doesn't account for burns/mints between timestamps)
+
+#### Supported Networks
+
+- Base (Chain ID: 8453) - Default
+- Other networks supported by @zoralabs/coins-sdk
+
+#### Dependencies
+
+- `@zoralabs/coins-sdk` - For accessing Zora coin data and swap history

--- a/battle-score/bun.lock
+++ b/battle-score/bun.lock
@@ -1,0 +1,64 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "battle-score",
+      "dependencies": {
+        "@zoralabs/coins-sdk": "^0.2.11",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
+
+    "@hey-api/client-fetch": ["@hey-api/client-fetch@0.8.4", "", {}, "sha512-SWtUjVEFIUdiJGR2NiuF0njsSrSdTe7WHWkp3BLH3DEl2bRhiflOnBo29NSDdrY90hjtTQiTQkBxUgGOF29Xzg=="],
+
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
+    "@types/bun": ["@types/bun@1.2.20", "", { "dependencies": { "bun-types": "1.2.20" } }, "sha512-dX3RGzQ8+KgmMw7CsW4xT5ITBSCrSbfHc36SNT31EOUg/LA9JWq0VDdEXDRSe1InVWpd2yLUM1FUF/kEOyTzYA=="],
+
+    "@types/node": ["@types/node@24.2.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ=="],
+
+    "@types/react": ["@types/react@19.1.10", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg=="],
+
+    "@zoralabs/coins-sdk": ["@zoralabs/coins-sdk@0.2.11", "", { "dependencies": { "@hey-api/client-fetch": "^0.8.3", "@zoralabs/protocol-deployments": "^0.6.2" }, "peerDependencies": { "abitype": "^1.0.8", "viem": "^2.21.55" } }, "sha512-wcH4g8WTLYvua0PNw70qG/hDhqS+VGgrdjjwEs9Qo+bYQVdi3GJ07WQtFzhv9xuKZKddK0I64o67M7R0a9Z3MA=="],
+
+    "@zoralabs/protocol-deployments": ["@zoralabs/protocol-deployments@0.6.2", "", {}, "sha512-RvyoNtVwcEzCNLWKqIwYlIC60TzBoZhxYrwpLxBfvoBlWSvQ8wyoc1/Z1f5fqNMPOd2wjk/eK8FAhMgaHerJdQ=="],
+
+    "abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "bun-types": ["bun-types@1.2.20", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-pxTnQYOrKvdOwyiyd/7sMt9yFOenN004Y6O4lCcCUoKVej48FS5cvTw9geRaEcB9TsDZaJKAxPTVvi8tFsVuXA=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
+    "ox": ["ox@0.8.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-eiKcgiVVEGDtEpEdFi1EGoVVI48j6icXHce9nFwCNM7CKG3uoCXKdr4TPhS00Iy1TR2aWSF1ltPD0x/YgqIL9w=="],
+
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+
+    "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+
+    "viem": ["viem@2.33.3", "", { "dependencies": { "@noble/curves": "1.9.2", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.8.6", "ws": "8.18.2" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-aWDr6i6r3OfNCs0h9IieHFhn7xQJJ8YsuA49+9T5JRyGGAkWhLgcbLq2YMecgwM7HdUZpx1vPugZjsShqNi7Gw=="],
+
+    "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
+  }
+}

--- a/battle-score/package.json
+++ b/battle-score/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "battle-score",
+  "module": "index.ts",
+  "type": "module",
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@zoralabs/coins-sdk": "^0.2.11"
+  }
+}

--- a/battle-score/src/coinComparison.ts
+++ b/battle-score/src/coinComparison.ts
@@ -1,0 +1,155 @@
+import { 
+  getCoin, 
+  getCoinSwaps, 
+  type CoinData,
+} from '@zoralabs/coins-sdk';
+
+export interface CoinComparisonInput {
+  coinAddress1: string;
+  coinAddress2: string;
+  startTimestamp: number;
+  chainId?: number;
+}
+
+export interface CoinMetrics {
+  address: string;
+  symbol: string;
+  name: string;
+  startMarketCap: string;
+  currentMarketCap: string;
+  marketCapIncreaseUsdc: string;
+  percentageIncrease: number;
+}
+
+export interface CoinComparisonResult {
+  coin1: CoinMetrics;
+  coin2: CoinMetrics;
+  comparisonScore: number; // Ratio: coin1 increase / coin2 increase
+  winner: 'coin1' | 'coin2' | 'tie';
+}
+
+export async function compareCoinMarketCaps({
+  coinAddress1,
+  coinAddress2,
+  startTimestamp,
+  chainId = 8453 // Default to Base chain
+}: CoinComparisonInput): Promise<CoinComparisonResult> {
+  
+  // Get current data for both coins
+  const [coin1Result, coin2Result] = await Promise.all([
+    getCoin({ address: coinAddress1, chain: chainId }),
+    getCoin({ address: coinAddress2, chain: chainId })
+  ]);
+
+  if (!coin1Result.data?.zora20Token || !coin2Result.data?.zora20Token) {
+    throw new Error('Failed to fetch coin data');
+  }
+
+  const coin1Data: CoinData = coin1Result.data.zora20Token;
+  const coin2Data: CoinData = coin2Result.data.zora20Token;
+
+  // Get historical data for both coins to find market cap at start timestamp
+  const [coin1HistoricalCap, coin2HistoricalCap] = await Promise.all([
+    getHistoricalMarketCap(coinAddress1, startTimestamp, chainId, coin1Data.totalSupply),
+    getHistoricalMarketCap(coinAddress2, startTimestamp, chainId, coin2Data.totalSupply)
+  ]);
+
+  // Calculate metrics for coin1
+  const coin1CurrentCap = parseFloat(coin1Data.marketCap);
+  const coin1StartCap = coin1HistoricalCap;
+  const coin1Increase = coin1CurrentCap - coin1StartCap;
+  const coin1PercentIncrease = coin1StartCap > 0 ? (coin1Increase / coin1StartCap) * 100 : 0;
+
+  // Calculate metrics for coin2
+  const coin2CurrentCap = parseFloat(coin2Data.marketCap);
+  const coin2StartCap = coin2HistoricalCap;
+  const coin2Increase = coin2CurrentCap - coin2StartCap;
+  const coin2PercentIncrease = coin2StartCap > 0 ? (coin2Increase / coin2StartCap) * 100 : 0;
+
+  // Calculate comparison score and determine winner
+  const comparisonScore = coin2Increase > 0 ? coin1Increase / coin2Increase : coin1Increase > 0 ? Infinity : 1;
+  let winner: 'coin1' | 'coin2' | 'tie';
+  
+  if (Math.abs(coin1Increase - coin2Increase) < 0.01) {
+    winner = 'tie';
+  } else if (coin1Increase > coin2Increase) {
+    winner = 'coin1';
+  } else {
+    winner = 'coin2';
+  }
+
+  return {
+    coin1: {
+      address: coinAddress1,
+      symbol: coin1Data.symbol,
+      name: coin1Data.name,
+      startMarketCap: coin1StartCap.toFixed(2),
+      currentMarketCap: coin1Data.marketCap,
+      marketCapIncreaseUsdc: coin1Increase.toFixed(2),
+      percentageIncrease: coin1PercentIncrease
+    },
+    coin2: {
+      address: coinAddress2,
+      symbol: coin2Data.symbol,
+      name: coin2Data.name,
+      startMarketCap: coin2StartCap.toFixed(2),
+      currentMarketCap: coin2Data.marketCap,
+      marketCapIncreaseUsdc: coin2Increase.toFixed(2),
+      percentageIncrease: coin2PercentIncrease
+    },
+    comparisonScore,
+    winner
+  };
+}
+
+async function getHistoricalMarketCap(
+  coinAddress: string, 
+  targetTimestamp: number, 
+  chainId: number,
+  totalSupply: string
+): Promise<number> {
+  try {
+    // Get swap history to find price closest to target timestamp
+    const swapsResult = await getCoinSwaps({ 
+      address: coinAddress, 
+      chain: chainId,
+      first: 100 // Get more data for better timestamp matching
+    });
+
+    // Handle the RequestResult union type properly
+    if (!swapsResult || !swapsResult.data?.zora20Token?.swapActivities?.edges) {
+      throw new Error('No swap data available');
+    }
+
+    const swaps = swapsResult.data.zora20Token.swapActivities.edges;
+    
+    // Find the swap closest to target timestamp
+    let closestSwap: typeof swaps[0]['node'] | null = null;
+    let smallestTimeDiff = Infinity;
+
+    for (const edge of swaps) {
+      const swap = edge.node;
+      // Convert blockTimestamp (ISO string) to unix timestamp for comparison
+      const swapTimestamp = new Date(swap.blockTimestamp).getTime() / 1000;
+      const timeDiff = Math.abs(swapTimestamp - targetTimestamp);
+      
+      if (timeDiff < smallestTimeDiff && swap.currencyAmountWithPrice?.priceUsdc) {
+        smallestTimeDiff = timeDiff;
+        closestSwap = swap;
+      }
+    }
+
+    if (closestSwap?.currencyAmountWithPrice?.priceUsdc) {
+      const historicalPrice = parseFloat(closestSwap.currencyAmountWithPrice.priceUsdc);
+      const supply = parseFloat(totalSupply);
+      return historicalPrice * supply;
+    }
+
+    throw new Error('No historical price data found near target timestamp');
+    
+  } catch (error) {
+    console.warn(`Could not get historical market cap for ${coinAddress}:`, error);
+    // Return 0 as fallback - this means we can't calculate the increase accurately
+    return 0;
+  }
+}

--- a/battle-score/src/example.ts
+++ b/battle-score/src/example.ts
@@ -1,0 +1,24 @@
+import { compareCoinMarketCaps } from './coinComparison';
+
+// Example usage (wip)
+async function example() {
+  try {
+    const result = await compareCoinMarketCaps({
+      coinAddress1: '0x1234567890123456789012345678901234567890', // Replace with actual address
+      coinAddress2: '0x0987654321098765432109876543210987654321', // Replace with actual address
+      startTimestamp: Math.floor(Date.now() / 1000) - (7 * 24 * 60 * 60), // 7 days ago
+      chainId: 8453 // Base chain
+    });
+
+    console.log('Comparison Result:', result);
+    console.log(`Winner: ${result.winner}`);
+    console.log(`Coin 1 (${result.coin1.symbol}): $${result.coin1.marketCapIncreaseUsdc} increase (${result.coin1.percentageIncrease.toFixed(2)}%)`);
+    console.log(`Coin 2 (${result.coin2.symbol}): $${result.coin2.marketCapIncreaseUsdc} increase (${result.coin2.percentageIncrease.toFixed(2)}%)`);
+    console.log(`Comparison Score: ${result.comparisonScore.toFixed(2)}`);
+  } catch (error) {
+    console.error('Error comparing coins:', error);
+  }
+}
+
+// Uncomment to run:
+// example();

--- a/battle-score/src/index.ts
+++ b/battle-score/src/index.ts
@@ -1,0 +1,1 @@
+export { compareCoinMarketCaps } from "./coinComparison";

--- a/battle-score/tsconfig.json
+++ b/battle-score/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
## Summary
Implements `compareCoinMarketCaps()` function to compare market cap performance between two Zora creator coins over custom time periods.

- **New Function**: `compareCoinMarketCaps()` in `coinComparison.ts`

- Compare two creator coins' market cap changes from any start timestamp
- Calculate absolute USDC increases and percentage growth
- Determine winner with comparison scoring algorithm

## Technical Implementation
- Uses `@zoralabs/coins-sdk` for current market data via `getCoin()`
- Leverages `getCoinSwaps()` for historical price discovery

## Usage
```typescript
const result = await compareCoinMarketCaps({
  coinAddress1: '0x...',
  coinAddress2: '0x...',
  startTimestamp: Math.floor(Date.now() / 1000) - (7 * 24 * 60 * 60), // 7 days ago
});
// Returns winner, metrics, and comparison score
```